### PR TITLE
Return password metadata from setPassword

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Fixed
+- Response from `PUT /user/{employee_id}/password` is now returned from `setPassword` method.
 
 ## [2.5.0] - 2018-07-03
 ### Added

--- a/src/IdBrokerClient.php
+++ b/src/IdBrokerClient.php
@@ -368,13 +368,15 @@ class IdBrokerClient extends BaseClient
 
         $this->reportUnexpectedResponse($result, 1506710704, $statusCode);
     }
-    
+
     /**
      * Set the password for the specified user.
      *
      * @param string $employeeId The Employee ID of the user whose password we
      *     are trying to set.
      * @param string $password The desired (new) password, in plaintext.
+     *
+     * @return GuzzleHttp\Command\Result
      * @throws Exception
      */
     public function setPassword(string $employeeId, string $password)
@@ -388,6 +390,8 @@ class IdBrokerClient extends BaseClient
         if ($statusCode !== 200) {
             $this->reportUnexpectedResponse($result, 1490808839, $statusCode);
         }
+
+        return $result;
     }
     
     protected function reportUnexpectedResponse($response, $uniqueErrorCode, $httpStatusCode = null)

--- a/src/IdBrokerClient.php
+++ b/src/IdBrokerClient.php
@@ -376,7 +376,7 @@ class IdBrokerClient extends BaseClient
      *     are trying to set.
      * @param string $password The desired (new) password, in plaintext.
      *
-     * @return GuzzleHttp\Command\Result
+     * @return array An array of password metadata
      * @throws Exception
      */
     public function setPassword(string $employeeId, string $password)
@@ -386,12 +386,12 @@ class IdBrokerClient extends BaseClient
             'password' => $password,
         ]);
         $statusCode = (int)$result['statusCode'];
-        
-        if ($statusCode !== 200) {
-            $this->reportUnexpectedResponse($result, 1490808839, $statusCode);
+
+        if ($statusCode === 200) {
+            return $this->getResultAsArrayWithoutStatusCode($result);
         }
 
-        return $result;
+        $this->reportUnexpectedResponse($result, 1490808839, $statusCode);
     }
     
     protected function reportUnexpectedResponse($response, $uniqueErrorCode, $httpStatusCode = null)


### PR DESCRIPTION
ID Broker returns password metadata from the set password call, and idp-pw-api looks for this metadata. This PR bridges that gap.