### PR TITLE
Simplified error handling for Methods

### DIFF
--- a/features/response/ResponseContext.php
+++ b/features/response/ResponseContext.php
@@ -9,9 +9,6 @@ use GuzzleHttp\Handler\MockHandler;
 use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Psr7\Response;
 use PHPUnit\Framework\Assert;
-use Sil\Idp\IdBroker\Client\exceptions\MethodRateLimitException;
-use Sil\Idp\IdBroker\Client\exceptions\MethodResendException;
-use Sil\Idp\IdBroker\Client\exceptions\MethodVerifyException;
 use Sil\Idp\IdBroker\Client\exceptions\MfaRateLimitException;
 use Sil\Idp\IdBroker\Client\IdBrokerClient;
 
@@ -355,28 +352,6 @@ class ResponseContext implements Context
     }
 
     /**
-     * @Then a Method rate-limit exception SHOULD have been thrown
-     */
-    public function aMethodRateLimitExceptionShouldHaveBeenThrown()
-    {
-        Assert::assertInstanceOf(
-            MethodRateLimitException::class,
-            $this->exceptionThrown
-        );
-    }
-
-    /**
-     * @Then the Method verify exception SHOULD have been thrown
-     */
-    public function theMethodVerifyExceptionShouldHaveBeenThrown()
-    {
-        Assert::assertInstanceOf(
-            MethodVerifyException::class,
-            $this->exceptionThrown
-        );
-    }
-
-    /**
      * @When I call resendMethod with the necessary data
      */
     public function iCallResendMethodWithTheNecessaryData()
@@ -389,16 +364,5 @@ class ResponseContext implements Context
         } catch (Exception $e) {
             $this->exceptionThrown = $e;
         }
-    }
-
-    /**
-     * @Then the Method resend exception SHOULD have been thrown
-     */
-    public function theMethodResendExceptionShouldHaveBeenThrown()
-    {
-        Assert::assertInstanceOf(
-            MethodResendException::class,
-            $this->exceptionThrown
-        );
     }
 }

--- a/features/response/response.feature
+++ b/features/response/response.feature
@@ -165,22 +165,7 @@ Feature: Handling responses from the ID Broker API
     Then an exception should NOT have been thrown
     And the result should be an array
 
-  Scenario: Handling a rate-limited call to verifyMethod
-    Given a call to "verifyMethod" will return a 429 response
-    When I call verifyMethod with the necessary data
-    Then a Method rate-limit exception SHOULD have been thrown
-
   Scenario: Handling a "correct" response from verifyMethod
     Given a call to "verifyMethod" will return a 200 response
     When I call verifyMethod with the necessary data
     Then the result should be an array
-
-  Scenario: Handling a "wrong" response from verifyMethod
-    Given a call to "verifyMethod" will return a 400 response
-    When I call verifyMethod with the necessary data
-    Then the Method verify exception SHOULD have been thrown
-
-  Scenario: Handling a "wrong" response from resendMethod
-    Given a call to "resendMethod" will return a 400 response
-    When I call resendMethod with the necessary data
-    Then the Method resend exception SHOULD have been thrown

--- a/src/exceptions/MethodRateLimitException.php
+++ b/src/exceptions/MethodRateLimitException.php
@@ -1,6 +1,0 @@
-<?php
-namespace Sil\Idp\IdBroker\Client\exceptions;
-
-class MethodRateLimitException extends \Exception
-{
-}

--- a/src/exceptions/MethodResendException.php
+++ b/src/exceptions/MethodResendException.php
@@ -1,6 +1,0 @@
-<?php
-namespace Sil\Idp\IdBroker\Client\exceptions;
-
-class MethodResendException extends \Exception
-{
-}

--- a/src/exceptions/MethodVerifyException.php
+++ b/src/exceptions/MethodVerifyException.php
@@ -1,6 +1,0 @@
-<?php
-namespace Sil\Idp\IdBroker\Client\exceptions;
-
-class MethodVerifyException extends \Exception
-{
-}


### PR DESCRIPTION
Rather than throw custom exceptions for a few special cases, I decided it is cleaner to use the ServiceException object to pass the HTTP response code for all 400- and 500-level responses. Other than the endpoints affected by this PR, only two other endpoints handle 400-level responses differently: mfaVerify() and authenticate(). If I can change these without breaking other code, I would like to do so at a later time.