### PR TITLE
Add optional parameter to createMethod to pre-verify record

### DIFF
--- a/src/IdBrokerClient.php
+++ b/src/IdBrokerClient.php
@@ -452,12 +452,18 @@ class IdBrokerClient extends BaseClient
      * Create a new recovery method
      * @param string $employee_id
      * @param string $value
+     * @param string $created If specified, indicates the record is to be created pre-verified.
      * @return String[]
      * @throws ServiceException
      */
-    public function createMethod($employee_id, $value)
+    public function createMethod($employee_id, $value, $created = '')
     {
-        $result = $this->createMethodInternal(compact('employee_id', 'value'));
+        $params = compact('employee_id', 'value');
+        if (! empty($created)) {
+            $params['created'] = $created;
+        }
+
+        $result = $this->createMethodInternal($params);
         $statusCode = (int)$result[ 'statusCode' ];
 
         if ($statusCode === 200) {

--- a/src/descriptions/id-broker-api.php
+++ b/src/descriptions/id-broker-api.php
@@ -351,6 +351,11 @@
                     'type' => 'string',
                     'location' => 'json',
                 ],
+                'created' => [
+                    'required' => false,
+                    'type' => 'string',
+                    'location' => 'json',
+                ],
             ],
         ],
         'deleteMethodInternal' => [


### PR DESCRIPTION
This is primarily used for moving method records from idp-pw-api to idp-id-broker, but could also be used for adding fake data for automated testing.