### PR TITLE
mfaVerify() returns mfa object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Changed
+- 'mfaVerify' now returns the MFA object
 
 ## [2.6.0] - 2019-02-04
 ### Added

--- a/features/response/ResponseContext.php
+++ b/features/response/ResponseContext.php
@@ -11,6 +11,7 @@ use GuzzleHttp\Psr7\Response;
 use PHPUnit\Framework\Assert;
 use Sil\Idp\IdBroker\Client\exceptions\MfaRateLimitException;
 use Sil\Idp\IdBroker\Client\IdBrokerClient;
+use Sil\Idp\IdBroker\Client\ServiceException;
 
 /**
  * Defines application features from the specific context.
@@ -275,6 +276,15 @@ class ResponseContext implements Context
     public function anExceptionShouldHaveBeenThrown()
     {
         Assert::assertInstanceOf(Exception::class, $this->exceptionThrown);
+    }
+
+    /**
+     * @Then an exception with status code :code SHOULD have been thrown
+     */
+    public function anExceptionWithStatusCodeShouldHaveBeenThrown($code)
+    {
+        Assert::assertInstanceOf(ServiceException::class, $this->exceptionThrown);
+        Assert::equalTo(400, $this->exceptionThrown->httpStatusCode);
     }
 
     /**

--- a/features/response/ResponseContext.php
+++ b/features/response/ResponseContext.php
@@ -280,11 +280,16 @@ class ResponseContext implements Context
 
     /**
      * @Then an exception with status code :code SHOULD have been thrown
+     * @param $code
      */
     public function anExceptionWithStatusCodeShouldHaveBeenThrown($code)
     {
         Assert::assertInstanceOf(ServiceException::class, $this->exceptionThrown);
-        Assert::assertEquals($code, $this->exceptionThrown->httpStatusCode);
+        /**
+         * @var ServiceException $exception
+         */
+        $exception = $this->exceptionThrown;
+        Assert::assertEquals($code, $exception->httpStatusCode);
     }
 
     /**

--- a/features/response/ResponseContext.php
+++ b/features/response/ResponseContext.php
@@ -284,7 +284,7 @@ class ResponseContext implements Context
     public function anExceptionWithStatusCodeShouldHaveBeenThrown($code)
     {
         Assert::assertInstanceOf(ServiceException::class, $this->exceptionThrown);
-        Assert::equalTo(400, $this->exceptionThrown->httpStatusCode);
+        Assert::assertEquals($code, $this->exceptionThrown->httpStatusCode);
     }
 
     /**

--- a/features/response/response.feature
+++ b/features/response/response.feature
@@ -222,7 +222,12 @@ Feature: Handling responses from the ID Broker API
   Scenario: Handling a "wrong" response from mfaVerify
     Given a call to "mfaVerify" will return a 400 response
     When I call mfaVerify with the necessary data
-    Then the result should be false
+    Then an exception with status code 400 SHOULD have been thrown
+
+  Scenario: Handling a rate limit exception from mfaVerify
+    Given a call to "mfaVerify" will return a 429 response
+    When I call mfaVerify with the necessary data
+    Then an exception with status code 429 SHOULD have been thrown
 
   Scenario: Handling a successful createMethod call
     Given a call to "createMethod" will return a 200 response
@@ -234,3 +239,24 @@ Feature: Handling responses from the ID Broker API
     Given a call to "verifyMethod" will return a 200 response
     When I call verifyMethod with the necessary data
     Then the result should be an array
+
+  Scenario: Handling a "wrong" response from verifyMethod
+    Given a call to "verifyMethod" will return a 400 response
+    When I call verifyMethod with the necessary data
+    Then an exception with status code 400 SHOULD have been thrown
+
+  Scenario: Handling a "not found" exception from verifyMethod
+    Given a call to "verifyMethod" will return a 404 response
+    When I call verifyMethod with the necessary data
+    Then an exception with status code 404 SHOULD have been thrown
+
+  Scenario: Handling a "expired code" exception from verifyMethod
+    Given a call to "verifyMethod" will return a 410 response
+    When I call verifyMethod with the necessary data
+    Then an exception with status code 410 SHOULD have been thrown
+
+  Scenario: Handling a rate limit exception from verifyMethod
+    Given a call to "verifyMethod" will return a 429 response
+    When I call verifyMethod with the necessary data
+    Then an exception with status code 429 SHOULD have been thrown
+

--- a/features/response/response.feature
+++ b/features/response/response.feature
@@ -208,12 +208,13 @@ Feature: Handling responses from the ID Broker API
     When I call setPassword with the necessary data
     Then an exception should NOT have been thrown
 
-  Scenario: Handling a rate-limited call to mfaVerify
-    Given a call to "mfaVerify" will return a 429 response
-    When I call mfaVerify with the necessary data
-    Then an MFA rate-limit exception SHOULD have been thrown
-
   Scenario: Handling a "correct" response from mfaVerify
+    Given a call to "mfaVerify" will return a 200 response
+    When I call mfaVerify with the necessary data
+    Then an exception should NOT have been thrown
+    And the result should be an array
+
+  Scenario: Handling a "correct," but empty response from mfaVerify
     Given a call to "mfaVerify" will return a 204 response
     When I call mfaVerify with the necessary data
     Then the result should be true

--- a/src/exceptions/MfaRateLimitException.php
+++ b/src/exceptions/MfaRateLimitException.php
@@ -1,6 +1,0 @@
-<?php
-namespace Sil\Idp\IdBroker\Client\exceptions;
-
-class MfaRateLimitException extends \Exception
-{
-}


### PR DESCRIPTION
- `mfaVerify()` now returns the mfa object instead of 204 and empty body
- simplified return value and exceptions on `mfaVerify()`