### PR TITLE
Release 3.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+
+## [3.0.0] - 2019-03-13
 ### Changed
 - 'mfaVerify' now returns the MFA object
-
 ### Removed
 - Removed `spouse_email` from User
 
@@ -67,7 +68,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - Initial version of ID Broker API client.
 
-[Unreleased]: https://github.com/silinternational/idp-id-broker-php-client/compare/2.5.1...HEAD
+[Unreleased]: https://github.com/silinternational/idp-id-broker-php-client/compare/3.0.0...HEAD
+[3.0.0]: https://github.com/silinternational/idp-id-broker-php-client/compare/2.6.0...3.0.0
 [2.6.0]: https://github.com/silinternational/idp-id-broker-php-client/compare/2.5.1...2.6.0
 [2.5.1]: https://github.com/silinternational/idp-id-broker-php-client/compare/2.5.0...2.5.1
 [2.5.0]: https://github.com/silinternational/idp-id-broker-php-client/compare/2.4.0...2.5.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,16 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+
+## [2.6.0] - 2019-02-04
 ### Added
 - Added support for recovery method endpoints.
 - Added `hide` property on `user`
 - Added mfaUpdate() (`PUT /mfa/{mfaId}`) to update MFA label.
 - Added authenticateNewUser() to authenticate using an invite code.
 - Added new MFA type, `manager`, for sending a "rescue" code to user's manager.
+### Changed
+- Tighter validation on idBrokerUri
 
 ## [2.5.1] - 2018-11-01
 ### Fixed
@@ -57,7 +61,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - Initial version of ID Broker API client.
 
-[Unreleased]: https://github.com/silinternational/idp-id-broker-php-client/compare/2.5.0...HEAD
+[Unreleased]: https://github.com/silinternational/idp-id-broker-php-client/compare/2.5.1...HEAD
+[2.6.0]: https://github.com/silinternational/idp-id-broker-php-client/compare/2.5.1...2.6.0
 [2.5.1]: https://github.com/silinternational/idp-id-broker-php-client/compare/2.5.0...2.5.1
 [2.5.0]: https://github.com/silinternational/idp-id-broker-php-client/compare/2.4.0...2.5.0
 [2.4.0]: https://github.com/silinternational/idp-id-broker-php-client/compare/2.3.0...2.4.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [3.0.0] - 2019-03-13
 ### Changed
 - 'mfaVerify' now returns the MFA object
+- change 'email' to not required on createUser to support onboarding use case
 ### Removed
 - Removed `spouse_email` from User
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Added mfaUpdate() (`PUT /mfa/{mfaId}`) to update MFA label.
 - Added authenticateNewUser() to authenticate using an invite code.
 - Added new MFA type, `manager`, for sending a "rescue" code to user's manager.
+- Added 'personal_email' and 'groups' properties on User.
 ### Changed
 - Tighter validation on idBrokerUri
 

--- a/codeship-services.yml
+++ b/codeship-services.yml
@@ -3,6 +3,6 @@ php:
   volumes:
     - ./:/data
   extra_hosts:
-    - "trusted_host.org.:10.0.1.1"
-    - "untrusted_host.org.:22.0.1.1"
+    - "trusted_host.org:10.0.1.1"
+    - "untrusted_host.org:22.0.1.1"
   working_dir: /data

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,6 @@ services:
     volumes:
       - ./:/data
     extra_hosts:
-     - "trusted_host.org.:10.0.1.1"
-     - "untrusted_host.org.:22.0.1.1"
+     - "trusted_host.org:10.0.1.1"
+     - "untrusted_host.org:22.0.1.1"
     working_dir: /data

--- a/features/request/RequestContext.php
+++ b/features/request/RequestContext.php
@@ -1,7 +1,6 @@
 <?php
 namespace Sil\Idp\IdBroker\Client\features\request;
 
-use Behat\Behat\Tester\Exception\PendingException;
 use Behat\Gherkin\Node\TableNode;
 use Behat\Gherkin\Node\PyStringNode;
 use Behat\Behat\Context\Context;

--- a/src/IdBrokerClient.php
+++ b/src/IdBrokerClient.php
@@ -8,31 +8,26 @@ use Sil\Idp\IdBroker\Client\exceptions\MfaRateLimitException;
 
 /**
  * IdP ID Broker API client implemented with Guzzle.
- * @method Result authenticateInternal(string[] $parameters) Authenticate user. Parameters: username, password
- * @method Result authenticateNewUserInternal(string[] $parameters) Authenticate new user. Parameters: invite
- * @method Result createUserInternal(string[] $parameters) Create user. Parameters: employee_id, first_name,
- *                                                         last_name, display_name, username, email, active, locked,
- *                                                         manager_email, require_mfa, spouse_email, hide, groups
- * @method Result deactivateUserInternal(string[] $parameters) Deactivate user. Parameters: employee_id, active
+ * @method Result authenticateInternal(string[] $parameters) Authenticate user.
+ * @method Result authenticateNewUserInternal(string[] $parameters) Authenticate new user.
+ * @method Result createUserInternal(string[] $parameters) Create user.
+ * @method Result deactivateUserInternal(string[] $parameters) Deactivate user.
  * @method Result getSiteStatusInternal() Get site status.
- * @method Result getUserInternal(string[] $parameters) Get user. Parameters: employee_id
- * @method Result listUsersInternal(string[] $parameters) List users. Parameters: fields, username, email
- * @method Result mfaCreateInternal(string[] $parameters) Create MFA. Parameters: employee_id, type, label
- * @method Result mfaDeleteInternal(string[] $parameters) Delete MFA. Parameters: id, employee_id
- * @method Result mfaListInternal(string[] $parameters) List MFAs. Parameters: employee_id
- * @method Result mfaUpdateInternal(string[] $parameters) Update MFA. Parameters: id, employee_id, label
- * @method Result mfaVerifyInternal(string[] $parameters) Verify MFA. Parameters: id, employee_id, value
- * @method Result createMethodInternal(string[] $parameters) Create recovery method. Parameters: employee_id, value
- * @method Result deleteMethodInternal(string[] $parameters) Delete recovery method. Parameters: uid, employee_id
- * @method Result getMethodInternal(string[] $parameters) Get recovery method. Parameters: uid, employee_id
- * @method Result listMethodInternal(string[] $parameters) List recovery methods. Parameters: employee_id
- * @method Result verifyMethodInternal(string[] $parameters) Verify recovery method. Parameters: uid, employee_id, code
- * @method Result resendMethodInternal(string[] $parameters) Resend recovery method verification. Parameters: uid,
- *                                                           employee_id
- * @method Result setPasswordInternal(string[] $parameters) Set password. Parameters: employee_id, password
- * @method Result updateUserInternal(string[] $parameters) Update user. Parameters: employee_id, first_name, last_name,
- *                                                         display_name, username, email, active, locked, manager_email,
- *                                                         require_mfa, spouse_email, hide, groups
+ * @method Result getUserInternal(string[] $parameters) Get user.
+ * @method Result listUsersInternal(string[] $parameters) List users.
+ * @method Result mfaCreateInternal(string[] $parameters) Create MFA.
+ * @method Result mfaDeleteInternal(string[] $parameters) Delete MFA.
+ * @method Result mfaListInternal(string[] $parameters) List MFAs.
+ * @method Result mfaUpdateInternal(string[] $parameters) Update MFA.
+ * @method Result mfaVerifyInternal(string[] $parameters) Verify MFA.
+ * @method Result createMethodInternal(string[] $parameters) Create recovery method.
+ * @method Result deleteMethodInternal(string[] $parameters) Delete recovery method.
+ * @method Result getMethodInternal(string[] $parameters) Get recovery method.
+ * @method Result listMethodInternal(string[] $parameters) List recovery methods.
+ * @method Result verifyMethodInternal(string[] $parameters) Verify recovery method.
+ * @method Result resendMethodInternal(string[] $parameters) Resend recovery method verification.
+ * @method Result setPasswordInternal(string[] $parameters) Set password.
+ * @method Result updateUserInternal(string[] $parameters) Update user.
  */
 class IdBrokerClient extends BaseClient
 {

--- a/src/IdBrokerClient.php
+++ b/src/IdBrokerClient.php
@@ -8,26 +8,6 @@ use Sil\Idp\IdBroker\Client\exceptions\MfaRateLimitException;
 
 /**
  * IdP ID Broker API client implemented with Guzzle.
- * @method Result authenticateInternal(string[] $parameters) Authenticate user.
- * @method Result authenticateNewUserInternal(string[] $parameters) Authenticate new user.
- * @method Result createUserInternal(string[] $parameters) Create user.
- * @method Result deactivateUserInternal(string[] $parameters) Deactivate user.
- * @method Result getSiteStatusInternal() Get site status.
- * @method Result getUserInternal(string[] $parameters) Get user.
- * @method Result listUsersInternal(string[] $parameters) List users.
- * @method Result mfaCreateInternal(string[] $parameters) Create MFA.
- * @method Result mfaDeleteInternal(string[] $parameters) Delete MFA.
- * @method Result mfaListInternal(string[] $parameters) List MFAs.
- * @method Result mfaUpdateInternal(string[] $parameters) Update MFA.
- * @method Result mfaVerifyInternal(string[] $parameters) Verify MFA.
- * @method Result createMethodInternal(string[] $parameters) Create recovery method.
- * @method Result deleteMethodInternal(string[] $parameters) Delete recovery method.
- * @method Result getMethodInternal(string[] $parameters) Get recovery method.
- * @method Result listMethodInternal(string[] $parameters) List recovery methods.
- * @method Result verifyMethodInternal(string[] $parameters) Verify recovery method.
- * @method Result resendMethodInternal(string[] $parameters) Resend recovery method verification.
- * @method Result setPasswordInternal(string[] $parameters) Set password.
- * @method Result updateUserInternal(string[] $parameters) Update user.
  */
 class IdBrokerClient extends BaseClient
 {

--- a/src/IdBrokerClient.php
+++ b/src/IdBrokerClient.php
@@ -635,20 +635,9 @@ class IdBrokerClient extends BaseClient
     private function assertTrustedBrokerIp()
     {
         $baseHost = parse_url($this->idBrokerUri, PHP_URL_HOST);
-        if ($baseHost === null) {
-            throw new Exception(
-                'The configured idBrokerUri ' . $this->idBrokerUri . ' is not valid',
-                1549291514
-            );
-        }
-
-        $idBrokerIp = gethostbyname($baseHost . '.');
-        if ($idBrokerIp === $baseHost . '.') {
-            throw new Exception(
-                'Could not resolve idBrokerUri ' . $this->idBrokerUri,
-                1549292074
-            );
-        }
+        $idBrokerIp = gethostbyname(
+            $baseHost
+        );
 
         if (! $this->isTrustedIpAddress($idBrokerIp)) {
             throw new Exception(

--- a/src/descriptions/id-broker-api.php
+++ b/src/descriptions/id-broker-api.php
@@ -108,6 +108,11 @@
                     'type' => 'string',
                     'location' => 'json',
                 ],
+                'personal_email' => [
+                    'required' => false,
+                    'type' => 'string',
+                    'location' => 'json',
+                ],
             ],
         ],
         'deactivateUserInternal' => [
@@ -346,6 +351,11 @@
                     'location' => 'json',
                 ],
                 'groups' => [
+                    'required' => false,
+                    'type' => 'string',
+                    'location' => 'json',
+                ],
+                'personal_email' => [
                     'required' => false,
                     'type' => 'string',
                     'location' => 'json',

--- a/src/descriptions/id-broker-api.php
+++ b/src/descriptions/id-broker-api.php
@@ -65,7 +65,7 @@
                     'location' => 'json',
                 ],
                 'email' => [
-                    'required' => true,
+                    'required' => false,
                     'type' => 'string',
                     'location' => 'json',
                 ],


### PR DESCRIPTION
Breaking change:
- remove `spouse_email` property from `user` endpoints

Also:
- With 200 response from `mfaVerify` return `mfa` object
- Allow `createUser` without `email`