### PR TITLE
Switch to using our standard PHP 7.4 docker image for CI/CD tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Fixed
+- Switch to using our standard PHP 7.4 docker image for CI/CD tests
 
 ## [4.0.0] - 2021-12-14
 ### Breaking Change

--- a/codeship-services.yml
+++ b/codeship-services.yml
@@ -1,5 +1,5 @@
 php:
-  image: silintl/php7-apache:7.4.19
+  image: silintl/php7:7.4
   volumes:
     - ./:/data
   extra_hosts:


### PR DESCRIPTION
### Fixed
- Switch to using our standard PHP 7.4 docker image for CI/CD tests