### PR TITLE
Release 4.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+
+## [4.0.1] - 2022-01-26
 ### Fixed
 - Switch to using our standard PHP 7.4 docker image for CI/CD tests
 
@@ -85,7 +87,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - Initial version of ID Broker API client.
 
-[Unreleased]: https://github.com/silinternational/idp-id-broker-php-client/compare/4.0.0...HEAD
+[Unreleased]: https://github.com/silinternational/idp-id-broker-php-client/compare/4.0.1...HEAD
+[4.0.1]: https://github.com/silinternational/idp-id-broker-php-client/compare/4.0.0...4.0.1
 [4.0.0]: https://github.com/silinternational/idp-id-broker-php-client/compare/3.2.0...4.0.0
 [3.2.0]: https://github.com/silinternational/idp-id-broker-php-client/compare/3.1.0...3.2.0
 [3.1.0]: https://github.com/silinternational/idp-id-broker-php-client/compare/3.0.0...3.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+
+## [4.0.0] - 2021-12-14
 ### Breaking Change
 - Added parameter for $rpOrigin to mfaCreate, mfaList, mfaVerify, and authenticateUser
   methods. This parameter is needed for WebAuthn MFA methods. 
@@ -81,7 +83,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - Initial version of ID Broker API client.
 
-[Unreleased]: https://github.com/silinternational/idp-id-broker-php-client/compare/3.2.0...HEAD
+[Unreleased]: https://github.com/silinternational/idp-id-broker-php-client/compare/4.0.0...HEAD
+[4.0.0]: https://github.com/silinternational/idp-id-broker-php-client/compare/3.2.0...4.0.0
 [3.2.0]: https://github.com/silinternational/idp-id-broker-php-client/compare/3.1.0...3.2.0
 [3.1.0]: https://github.com/silinternational/idp-id-broker-php-client/compare/3.0.0...3.1.0
 [3.0.0]: https://github.com/silinternational/idp-id-broker-php-client/compare/2.6.0...3.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Fixed
+- Switch to using our standard PHP 7.4 docker image for CI/CD tests
 
 ## [4.0.0] - 2021-12-14
 ### Breaking Change

--- a/codeship-services.yml
+++ b/codeship-services.yml
@@ -1,5 +1,5 @@
 php:
-  image: silintl/php7-apache:7.4.19
+  image: silintl/php7:7.4
   volumes:
     - ./:/data
   extra_hosts:


### PR DESCRIPTION
### Fixed
- Switch to using our standard PHP 7.4 docker image for CI/CD tests