### PR TITLE
log a more accurate error message for DNS failure

### DIFF
--- a/src/IdBrokerClient.php
+++ b/src/IdBrokerClient.php
@@ -717,9 +717,12 @@ class IdBrokerClient extends BaseClient
     private function assertTrustedBrokerIp()
     {
         $baseHost = parse_url($this->idBrokerUri, PHP_URL_HOST);
-        $idBrokerIp = gethostbyname(
-            $baseHost
-        );
+        if ($baseHost == ($idBrokerIp = gethostbyname($baseHost))) {
+            throw new Exception(
+                'DNS lookup failure on broker host ' . $baseHost,
+                1687147214
+            );
+        }
 
         if (! $this->isTrustedIpAddress($idBrokerIp)) {
             throw new Exception(


### PR DESCRIPTION
### Fixed
- Log a more accurate error message for DNS failure.