### PR TITLE
Add recovery email parameter to MFA creation

### DIFF
--- a/features/request/RequestContext.php
+++ b/features/request/RequestContext.php
@@ -474,13 +474,22 @@ class RequestContext implements Context
      */
     public function iCallMfaCreate()
     {
-        $this->getIdBrokerClient()->mfaCreate(
-            $this->requestData['employee_id'],
-            $this->requestData['type'],
-            $this->requestData['label'],
-            $this->rpOrigin,
-            $this->requestData['recovery_email'],
-        );
+        if (empty($this->requestData['recovery_email'])) {
+            $this->getIdBrokerClient()->mfaCreate(
+                $this->requestData['employee_id'],
+                $this->requestData['type'],
+                $this->requestData['label'],
+                $this->rpOrigin,
+            );
+        } else {
+            $this->getIdBrokerClient()->mfaCreate(
+                $this->requestData['employee_id'],
+                $this->requestData['type'],
+                $this->requestData['label'],
+                $this->rpOrigin,
+                $this->requestData['recovery_email'],
+            );
+        }
     }
 
     /**

--- a/features/request/RequestContext.php
+++ b/features/request/RequestContext.php
@@ -478,7 +478,8 @@ class RequestContext implements Context
             $this->requestData['employee_id'],
             $this->requestData['type'],
             $this->requestData['label'],
-            $this->rpOrigin
+            $this->rpOrigin,
+            $this->requestData['recovery_email'],
         );
     }
 

--- a/features/request/RequestContext.php
+++ b/features/request/RequestContext.php
@@ -474,22 +474,13 @@ class RequestContext implements Context
      */
     public function iCallMfaCreate()
     {
-        if (empty($this->requestData['recovery_email'])) {
-            $this->getIdBrokerClient()->mfaCreate(
-                $this->requestData['employee_id'],
-                $this->requestData['type'],
-                $this->requestData['label'],
-                $this->rpOrigin,
-            );
-        } else {
-            $this->getIdBrokerClient()->mfaCreate(
-                $this->requestData['employee_id'],
-                $this->requestData['type'],
-                $this->requestData['label'],
-                $this->rpOrigin,
-                $this->requestData['recovery_email'],
-            );
-        }
+        $this->getIdBrokerClient()->mfaCreate(
+            $this->requestData['employee_id'],
+            $this->requestData['type'],
+            $this->requestData['label'],
+            $this->rpOrigin,
+            $this->requestData['recovery_email'] ?? '',
+        );
     }
 
     /**

--- a/features/request/request.feature
+++ b/features/request/request.feature
@@ -328,7 +328,8 @@ Feature: Formatting requests for sending to the ID Broker API
         {
           "employee_id": "12345",
           "type": "webauthn",
-          "label": "Blue security key"
+          "label": "Blue security key",
+          "recovery_email": ""
         }
         """
 

--- a/features/request/request.feature
+++ b/features/request/request.feature
@@ -319,7 +319,6 @@ Feature: Formatting requests for sending to the ID Broker API
       And I provide an "employee_id" of "12345"
       And I provide a "type" of "webauthn"
       And I provide a "label" of "Blue security key"
-      And I provide a "recovery_email" of "recovery@example.com"
     When I call mfaCreate
     Then the method should be "POST"
       And the url should be "https://api.example.com/mfa?rpOrigin=https%3A%2F%2Flogin.example.com"
@@ -329,6 +328,27 @@ Feature: Formatting requests for sending to the ID Broker API
         {
           "employee_id": "12345",
           "type": "webauthn",
+          "label": "Blue security key"
+        }
+        """
+
+  Scenario: Creating an mfa recovery option
+    Given I am using a baseUri of "https://api.example.com/"
+      And I have indicated not to validate the id broker ip
+      And I have provided an rpOrigin of "https://login.example.com"
+      And I provide an "employee_id" of "12345"
+      And I provide a "type" of "recovery"
+      And I provide a "label" of "Blue security key"
+      And I provide a "recovery_email" of "recovery@example.com"
+    When I call mfaCreate
+    Then the method should be "POST"
+      And the url should be "https://api.example.com/mfa?rpOrigin=https%3A%2F%2Flogin.example.com"
+      And an authorization header should be present
+      And the body should equal the following:
+        """
+        {
+          "employee_id": "12345",
+          "type": "recovery",
           "label": "Blue security key",
           "recovery_email": "recovery@example.com"
         }

--- a/features/request/request.feature
+++ b/features/request/request.feature
@@ -319,6 +319,7 @@ Feature: Formatting requests for sending to the ID Broker API
       And I provide an "employee_id" of "12345"
       And I provide a "type" of "webauthn"
       And I provide a "label" of "Blue security key"
+      And I provide a "recovery_email" of "recovery@example.com"
     When I call mfaCreate
     Then the method should be "POST"
       And the url should be "https://api.example.com/mfa?rpOrigin=https%3A%2F%2Flogin.example.com"
@@ -328,7 +329,8 @@ Feature: Formatting requests for sending to the ID Broker API
         {
           "employee_id": "12345",
           "type": "webauthn",
-          "label": "Blue security key"
+          "label": "Blue security key",
+          "recovery_email": "recovery@example.com"
         }
         """
 

--- a/src/IdBrokerClient.php
+++ b/src/IdBrokerClient.php
@@ -316,26 +316,17 @@ class IdBrokerClient extends BaseClient
      * @return array|null
      * @throws ServiceException
      */
-    public function mfaCreate(string $employee_id, string $type, string $label = null, string $rpOrigin = '', ?string $recovery_email = null): ?array
+    public function mfaCreate(string $employee_id, string $type, string $label = null, string $rpOrigin = '', string $recovery_email = ''): ?array
     {
-        if ($recovery_email === null) {
-            $result = $this->mfaCreateInternal([
-                'employee_id' => $employee_id,
-                'type' => $type,
-                'label' => $label,
-                'rpOrigin' => $rpOrigin,
-            ]);
-        }
-        else{
-            $result = $this->mfaCreateInternal([
-                'employee_id' => $employee_id,
-                'type' => $type,
-                'label' => $label,
-                'rpOrigin' => $rpOrigin,
-                'recovery_email' => $recovery_email,
-            ]);
-        }
-        
+        var_dump($recovery_email);
+        $result = $this->mfaCreateInternal([
+            'employee_id' => $employee_id,
+            'type' => $type,
+            'label' => $label,
+            'rpOrigin' => $rpOrigin,
+            'recovery_email'=> $recovery_email
+        ]);
+
         $statusCode = (int)$result[ 'statusCode' ];
 
         if ($statusCode === 200) {

--- a/src/IdBrokerClient.php
+++ b/src/IdBrokerClient.php
@@ -312,16 +312,18 @@ class IdBrokerClient extends BaseClient
      * @param string $type
      * @param string|null $label
      * @param string|null $rpOrigin
+     * @param string|null $recovery_email
      * @return array|null
      * @throws ServiceException
      */
-    public function mfaCreate(string $employee_id, string $type, string $label = null, string $rpOrigin = ''): ?array
+    public function mfaCreate(string $employee_id, string $type, string $label = null, string $rpOrigin = '', string $recovery_email = null): ?array
     {
         $result = $this->mfaCreateInternal([
             'employee_id' => $employee_id,
             'type' => $type,
             'label' => $label,
             'rpOrigin' => $rpOrigin,
+            'recovery_email' => $recovery_email,
         ]);
         $statusCode = (int)$result[ 'statusCode' ];
 

--- a/src/IdBrokerClient.php
+++ b/src/IdBrokerClient.php
@@ -318,7 +318,6 @@ class IdBrokerClient extends BaseClient
      */
     public function mfaCreate(string $employee_id, string $type, string $label = null, string $rpOrigin = '', string $recovery_email = ''): ?array
     {
-        var_dump($recovery_email);
         $result = $this->mfaCreateInternal([
             'employee_id' => $employee_id,
             'type' => $type,

--- a/src/IdBrokerClient.php
+++ b/src/IdBrokerClient.php
@@ -316,15 +316,26 @@ class IdBrokerClient extends BaseClient
      * @return array|null
      * @throws ServiceException
      */
-    public function mfaCreate(string $employee_id, string $type, string $label = null, string $rpOrigin = '', string $recovery_email = null): ?array
+    public function mfaCreate(string $employee_id, string $type, string $label = null, string $rpOrigin = '', ?string $recovery_email = null): ?array
     {
-        $result = $this->mfaCreateInternal([
-            'employee_id' => $employee_id,
-            'type' => $type,
-            'label' => $label,
-            'rpOrigin' => $rpOrigin,
-            'recovery_email' => $recovery_email,
-        ]);
+        if ($recovery_email === null) {
+            $result = $this->mfaCreateInternal([
+                'employee_id' => $employee_id,
+                'type' => $type,
+                'label' => $label,
+                'rpOrigin' => $rpOrigin,
+            ]);
+        }
+        else{
+            $result = $this->mfaCreateInternal([
+                'employee_id' => $employee_id,
+                'type' => $type,
+                'label' => $label,
+                'rpOrigin' => $rpOrigin,
+                'recovery_email' => $recovery_email,
+            ]);
+        }
+        
         $statusCode = (int)$result[ 'statusCode' ];
 
         if ($statusCode === 200) {

--- a/src/descriptions/id-broker-api.php
+++ b/src/descriptions/id-broker-api.php
@@ -182,7 +182,7 @@
                     'required' => true,
                     'type' => 'string',
                     'location' => 'json',
-                    'enum' => [ 'backupcode', 'totp', 'u2f', 'webauthn', 'manager' ],
+                    'enum' => [ 'backupcode', 'totp', 'u2f', 'webauthn', 'manager', 'recovery' ],
                 ],
                 'label' => [
                     'required' => false,
@@ -193,6 +193,11 @@
                     'required' => false,
                     'type' => 'string',
                     'location' => 'query',
+                ],
+                'recovery_email' => [
+                    'required' => false,
+                    'type' => 'string',
+                    'location' => 'json',
                 ],
             ],
         ],


### PR DESCRIPTION
This PR adds support for including a recovery email when creating MFA methods via the `mfaCreate` function.

### Addition

- Updated the mfaCreate method in `IdBrokerClient.php` to include a new recovery_email parameter.
- Modified the ID Broker API description in `id-broker-api.php` to define the new `recovery_email` field as an optional string in the request body.
- Added a `recovery` type to the enum list of valid MFA types.
- Updated the feature file `(request.feature)` to include a test scenario for the `recovery_email` field.
