### PR TITLE
Release 4.8.0 - Use a custom User-Agent string

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,26 @@
+### Added
+-
+
+### Changed (BREAKING ⚠️)
+-
+
+### Changed (non-breaking)
+-
+
+### Deprecated
+-
+
+### Removed
+-
+
+### Fixed
+-
+
+### Security
+-
+
+---
+
+Pull Request checklist:
+
+- [ ] If changing the major version, update `src/IdBrokerClient::VERSION_MAJOR`

--- a/features/request/RequestContext.php
+++ b/features/request/RequestContext.php
@@ -580,12 +580,21 @@ class RequestContext implements Context
         );
     }
 
-    #[Then('the user agent should be :expectedUserAgent')]
-    public function theUserAgentShouldBe($expectedUserAgent): void
+    #[Then('the user agent should start with :expectedPrefix')]
+    public function theUserAgentShouldStartWith($expectedPrefix): void
     {
         $request = $this->getRequestFromHistory();
         $actualUserAgents = $request->getHeader('User-Agent');
         $actualUserAgent = array_pop($actualUserAgents);
-        $this->assertSame($expectedUserAgent, $actualUserAgent);
+        Assert::assertStringStartsWith($expectedPrefix, $actualUserAgent);
+    }
+
+    #[Then('the user agent should end with the current version of this library')]
+    public function theUserAgentShouldEndWithTheCurrentVersionOfThisLibrary(): void
+    {
+        $request = $this->getRequestFromHistory();
+        $actualUserAgents = $request->getHeader('User-Agent');
+        $actualUserAgent = array_pop($actualUserAgents);
+        Assert::assertStringEndsWith(IdBrokerClient::VERSION_MAJOR, $actualUserAgent);
     }
 }

--- a/features/request/RequestContext.php
+++ b/features/request/RequestContext.php
@@ -1,9 +1,11 @@
 <?php
+
 namespace Sil\Idp\IdBroker\Client\features\request;
 
 use Behat\Gherkin\Node\TableNode;
 use Behat\Gherkin\Node\PyStringNode;
 use Behat\Behat\Context\Context;
+use Behat\Step\Then;
 use GuzzleHttp\Handler\MockHandler;
 use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Middleware;
@@ -576,5 +578,14 @@ class RequestContext implements Context
             'registration',
             $this->requestData['label'],
         );
+    }
+
+    #[Then('the user agent should be :expectedUserAgent')]
+    public function theUserAgentShouldBe($expectedUserAgent): void
+    {
+        $request = $this->getRequestFromHistory();
+        $actualUserAgents = $request->getHeader('User-Agent');
+        $actualUserAgent = array_pop($actualUserAgents);
+        $this->assertSame($expectedUserAgent, $actualUserAgent);
     }
 }

--- a/features/request/request.feature
+++ b/features/request/request.feature
@@ -487,4 +487,5 @@ Feature: Formatting requests for sending to the ID Broker API
     Given I am using a baseUri of "https://api.example.com/"
       And I have indicated not to validate the id broker ip
     When I call getSiteStatus
-    Then the user agent should be "IdpIdBrokerPhpClient/4"
+    Then the user agent should start with "IdpIdBrokerPhpClient/"
+     And the user agent should end with the current version of this library

--- a/features/request/request.feature
+++ b/features/request/request.feature
@@ -482,3 +482,9 @@ Feature: Formatting requests for sending to the ID Broker API
           "label": "Yubikey"
         }
         """
+
+  Scenario: Ensuring the correct User-Agent is used
+    Given I am using a baseUri of "https://api.example.com/"
+      And I have indicated not to validate the id broker ip
+    When I call getSiteStatus
+    Then the user agent should be "IdpIdBrokerPhpClient/4"

--- a/src/IdBrokerClient.php
+++ b/src/IdBrokerClient.php
@@ -12,6 +12,15 @@ use IPLib\Factory;
 class IdBrokerClient extends BaseClient
 {
     /**
+     * The major version number for this version of this library.
+     *
+     * NOTE: Update this manually.
+     *
+     * @var string
+     */
+    public const VERSION_MAJOR = '4';
+
+    /**
      * The key for the constructor's config parameter that refers
      * to the trusted IP ranges.
      */
@@ -73,6 +82,9 @@ class IdBrokerClient extends BaseClient
             'access_token' => $accessToken,
             'http_client_options' => [
                 'timeout' => 30,
+                'headers' => [
+                    'User-Agent' => 'IdpIdBrokerPhpClient/' . static::VERSION_MAJOR,
+                ],
             ],
         ], $config));
     }


### PR DESCRIPTION
### Added
- Give this library its own User-Agent string
- Add a PR checklist to help us remember to update the VERSION_MAJOR value (used in that User-Agent)