### PR TITLE
Release 4.8.1 - Rename silinternational to sil-org

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @silinternational/php-devs
+* @sil-org/php-devs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,19 +87,19 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - Initial version of ID Broker API client.
 
-[Unreleased]: https://github.com/silinternational/idp-id-broker-php-client/compare/4.0.1...HEAD
-[4.0.1]: https://github.com/silinternational/idp-id-broker-php-client/compare/4.0.0...4.0.1
-[4.0.0]: https://github.com/silinternational/idp-id-broker-php-client/compare/3.2.0...4.0.0
-[3.2.0]: https://github.com/silinternational/idp-id-broker-php-client/compare/3.1.0...3.2.0
-[3.1.0]: https://github.com/silinternational/idp-id-broker-php-client/compare/3.0.0...3.1.0
-[3.0.0]: https://github.com/silinternational/idp-id-broker-php-client/compare/2.6.0...3.0.0
-[2.6.0]: https://github.com/silinternational/idp-id-broker-php-client/compare/2.5.1...2.6.0
-[2.5.1]: https://github.com/silinternational/idp-id-broker-php-client/compare/2.5.0...2.5.1
-[2.5.0]: https://github.com/silinternational/idp-id-broker-php-client/compare/2.4.0...2.5.0
-[2.4.0]: https://github.com/silinternational/idp-id-broker-php-client/compare/2.3.0...2.4.0
-[2.3.0]: https://github.com/silinternational/idp-id-broker-php-client/compare/2.2.1...2.3.0
-[2.2.1]: https://github.com/silinternational/idp-id-broker-php-client/compare/2.2.0...2.2.1
-[2.2.0]: https://github.com/silinternational/idp-id-broker-php-client/compare/2.1.2...2.2.0
-[0.2.1]: https://github.com/silinternational/idp-id-broker-php-client/compare/0.2.0...0.2.1
-[0.2.0]: https://github.com/silinternational/idp-id-broker-php-client/compare/0.1.0...0.2.0
-[0.1.0]: https://github.com/silinternational/idp-id-broker-php-client/compare/071923e...0.1.0
+[Unreleased]: https://github.com/sil-org/idp-id-broker-php-client/compare/4.0.1...HEAD
+[4.0.1]: https://github.com/sil-org/idp-id-broker-php-client/compare/4.0.0...4.0.1
+[4.0.0]: https://github.com/sil-org/idp-id-broker-php-client/compare/3.2.0...4.0.0
+[3.2.0]: https://github.com/sil-org/idp-id-broker-php-client/compare/3.1.0...3.2.0
+[3.1.0]: https://github.com/sil-org/idp-id-broker-php-client/compare/3.0.0...3.1.0
+[3.0.0]: https://github.com/sil-org/idp-id-broker-php-client/compare/2.6.0...3.0.0
+[2.6.0]: https://github.com/sil-org/idp-id-broker-php-client/compare/2.5.1...2.6.0
+[2.5.1]: https://github.com/sil-org/idp-id-broker-php-client/compare/2.5.0...2.5.1
+[2.5.0]: https://github.com/sil-org/idp-id-broker-php-client/compare/2.4.0...2.5.0
+[2.4.0]: https://github.com/sil-org/idp-id-broker-php-client/compare/2.3.0...2.4.0
+[2.3.0]: https://github.com/sil-org/idp-id-broker-php-client/compare/2.2.1...2.3.0
+[2.2.1]: https://github.com/sil-org/idp-id-broker-php-client/compare/2.2.0...2.2.1
+[2.2.0]: https://github.com/sil-org/idp-id-broker-php-client/compare/2.1.2...2.2.0
+[0.2.1]: https://github.com/sil-org/idp-id-broker-php-client/compare/0.2.0...0.2.1
+[0.2.0]: https://github.com/sil-org/idp-id-broker-php-client/compare/0.1.0...0.2.0
+[0.1.0]: https://github.com/sil-org/idp-id-broker-php-client/compare/071923e...0.1.0

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2017 SIL International
+Copyright (c) 2017 SIL Global
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # idp-id-broker-php-client
-PHP client to interact with our [IdP ID Broker](https://github.com/silinternational/idp-id-broker)'s API.
+PHP client to interact with our [IdP ID Broker](https://github.com/sil-org/idp-id-broker)'s API.
 
 This client is built on top of 
 [Guzzle](http://docs.guzzlephp.org/en/stable/), the PHP HTTP Client. 
@@ -11,7 +11,7 @@ adding support for more APIs is relatively simple.
 ## Install ##
 Installation is simple with [Composer](https://getcomposer.org/):
 
-    $ composer require silinternational/idp-id-broker-php-client
+    $ composer require sil-org/idp-id-broker-php-client
 
 
 ## Usage ##

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
-  "name": "silinternational/idp-id-broker-php-client",
+  "name": "sil-org/idp-id-broker-php-client",
   "type": "library",
-  "description": "PHP client to interact with our IdP ID Broker's API: https://github.com/silinternational/idp-id-broker",
+  "description": "PHP client to interact with our IdP ID Broker's API: https://github.com/sil-org/idp-id-broker",
   "keywords": ["idp", "id broker", "api", "php client"],
   "license": "MIT",
   "require": {


### PR DESCRIPTION
### Changed (non-breaking)
- Rename silinternational to sil-org
- Rename SIL International to SIL Global

---

Pull Request checklist:

- [ ] If changing the major version, update `src/IdBrokerClient::VERSION_MAJOR`
