### PR TITLE
fix error handling bug

### DIFF
--- a/src/IdBrokerClient.php
+++ b/src/IdBrokerClient.php
@@ -788,8 +788,7 @@ class IdBrokerClient extends BaseClient
                 'Unexpected response: %s',
                 var_export($result, true)
             ),
-            1503511660,
-            (int)$result['statusCode']
+            1503511660
         );
     }
 


### PR DESCRIPTION

### Fixed
- Fixed a bug in error handling. When an email fails to send a type error would be thrown: 'Exception::__construct(): Argument # 3 ($previous) must be of type ?Throwable, int given'.
