### PR TITLE
Release 4.12.0 - add token fields added in idp-id-broker v8.7.0

### DIFF
--- a/src/descriptions/id-broker-api.php
+++ b/src/descriptions/id-broker-api.php
@@ -166,6 +166,11 @@
                     'type' => 'string',
                     'location' => 'query',
                 ],
+                'token_hash' => [
+                    'required' => false,
+                    'type' => 'string',
+                    'location' => 'query',
+                ],
             ]
         ],
         'mfaCreateInternal' => [
@@ -487,6 +492,21 @@
                     'location' => 'json',
                 ],
                 'personal_email' => [
+                    'required' => false,
+                    'type' => 'string',
+                    'location' => 'json',
+                ],
+                'token_hash' => [
+                    'required' => false,
+                    'type' => 'string',
+                    'location' => 'json',
+                ],
+                'token_expiry_utc' => [
+                    'required' => false,
+                    'type' => 'string',
+                    'location' => 'json',
+                ],
+                'token_type' => [
                     'required' => false,
                     'type' => 'string',
                     'location' => 'json',


### PR DESCRIPTION
[IDP-1967](https://support.gtis.sil.org/issue/IDP-1967) move access token storage to idp-id-broker

---

### Added
- Added `token_hash`, `token_expiry_utc`, and `token_type` to `updateUser()`
- Added `token_hash` to `listUsers()`
